### PR TITLE
Fixes and updates kafka example

### DIFF
--- a/databridge.examples/databridge.examples.kafka-jsonata-aas/pom.xml
+++ b/databridge.examples/databridge.examples.kafka-jsonata-aas/pom.xml
@@ -122,11 +122,19 @@
 
 		<!-- Zookeeper server -->
 		<dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-test</artifactId>
-            <version>5.5.0</version>
-            <scope>test</scope>
-        </dependency>
+			<groupId>org.apache.curator</groupId>
+			<artifactId>curator-test</artifactId>
+			<version>5.5.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.awaitility/awaitility -->
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<version>4.2.0</version>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 </project>

--- a/databridge.examples/databridge.examples.kafka-jsonata-aas/pom.xml
+++ b/databridge.examples/databridge.examples.kafka-jsonata-aas/pom.xml
@@ -9,8 +9,8 @@
 	</parent>
 
 	<artifactId>databridge.examples.kafka-jsonata-aas</artifactId>
-	<name>Kafka-JSONATA-AAS ETL</name>
-	<description>An Integration example using kafka as a data source, jsonata data transformer and aas sink</description>
+	<name>Kafka jsonATA AAS</name>
+	<description>An Integration example using kafka as a data source, jsonATA as data transformer and AAS as sink</description>
 
 
 	<packaging>jar</packaging>
@@ -111,6 +111,22 @@
 			<artifactId>kafka-clients</artifactId>
 			<version>3.4.0</version>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.apache.kafka/kafka -->
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka_2.13</artifactId>
+			<version>3.4.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Zookeeper server -->
+		<dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>5.5.0</version>
+            <scope>test</scope>
+        </dependency>
 
 	</dependencies>
 </project>

--- a/databridge.examples/databridge.examples.kafka-jsonata-aas/src/main/resources/kafkaconsumer.json
+++ b/databridge.examples/databridge.examples.kafka-jsonata-aas/src/main/resources/kafkaconsumer.json
@@ -7,7 +7,7 @@
 		"maxPollRecords": 5000,
 		"groupId": "basyx-updater",
 		"consumersCount": 1,
-		"seekTo": "latest"
+		"seekTo": "BEGINNING"
 	},
 	{
 		"uniqueId": "property2",
@@ -17,6 +17,6 @@
 		"maxPollRecords": 5000,
 		"groupId": "basyx-updater",
 		"consumersCount": 1,
-		"seekTo": "latest"
+		"seekTo": "BEGINNING"
 	}
 ]

--- a/databridge.examples/databridge.examples.kafka-jsonata-aas/src/test/java/org/eclipse/digitaltwin/basyx/databridge/examples/kafkajsonataaas/test/TestAASUpdater.java
+++ b/databridge.examples/databridge.examples.kafka-jsonata-aas/src/test/java/org/eclipse/digitaltwin/basyx/databridge/examples/kafkajsonataaas/test/TestAASUpdater.java
@@ -26,13 +26,21 @@ package org.eclipse.digitaltwin.basyx.databridge.examples.kafkajsonataaas.test;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.curator.test.TestingServer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Time;
 import org.eclipse.basyx.aas.manager.ConnectedAssetAdministrationShellManager;
 import org.eclipse.basyx.aas.metamodel.connected.ConnectedAssetAdministrationShell;
 import org.eclipse.basyx.aas.metamodel.map.descriptor.CustomId;
@@ -53,94 +61,210 @@ import org.eclipse.digitaltwin.basyx.databridge.kafka.configuration.factory.Kafk
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttPersistenceException;
 import org.eclipse.paho.client.mqttv3.MqttSecurityException;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import scala.Option;
+
+/**
+ * Tests the DataBridge scenario with Kafka
+ *
+ * @author haque, danish
+ *
+ */
 public class TestAASUpdater {
+
+	private static Logger logger = LoggerFactory.getLogger(TestAASUpdater.class);
 	private static AASServerComponent aasServer;
 	private static DataBridgeComponent updater;
-	private static InMemoryRegistry registry;
+	private static InMemoryRegistry registry = new InMemoryRegistry();
 
-	protected static IIdentifier deviceAAS = new CustomId("TestUpdatedDeviceAAS");
+	private static KafkaServer kafkaServer;
+
+	protected static IIdentifier deviceAASId = new CustomId("TestUpdatedDeviceAAS");
 	private static BaSyxContextConfiguration aasContextConfig;
 
-	@BeforeClass
-	public static void setUp() throws IOException {
-		registry = new InMemoryRegistry();
+	private static TestingServer zookeeper;
+	private static String kafkaTmpLogsDirPath;
 
-		aasContextConfig = new BaSyxContextConfiguration(4001, "");
-		BaSyxAASServerConfiguration aasConfig = new BaSyxAASServerConfiguration(AASServerBackend.INMEMORY, "aasx/updatertest.aasx");
-		aasServer = new AASServerComponent(aasContextConfig, aasConfig);
-		aasServer.setRegistry(registry);
+	@BeforeClass
+	public static void setUp() throws Exception {
+		configureAndStartKafkaServer();
+
+		configureAndStartAasServer();
+
+		configureAndStartUpdaterComponent();
 	}
 
-	@Ignore
+	@AfterClass
+	public static void tearDown() throws IOException {
+		updater.stopComponent();
+		
+		kafkaServer.shutdown();
+		kafkaServer.awaitShutdown();
+		
+	    zookeeper.close();
+		
+		aasServer.stopComponent();
+
+		clearLogs();
+	}
+
 	@Test
-	public void test() throws Exception {
+	public void getPropertyAValue() throws Exception {
+		publishNewDatapoint("first-topic");
+
+		waitForPropagation();
+
+		checkIfPropertyIsUpdated("336.36", "ConnectedPropertyA");
+	}
+	
+	@Test
+	public void getPropertyBValue() throws Exception {
+		publishNewDatapoint("second-topic");
+
+		waitForPropagation();
+
+		checkIfPropertyIsUpdated("858383", "ConnectedPropertyB");
+	}
+
+	private void waitForPropagation() throws InterruptedException {
+		Thread.sleep(5000);
+	}
+
+	private static void configureAndStartAasServer() {
+		aasContextConfig = new BaSyxContextConfiguration(4001, "");
+		BaSyxAASServerConfiguration aasConfig = new BaSyxAASServerConfiguration(AASServerBackend.INMEMORY,
+				"aasx/updatertest.aasx");
+		aasServer = new AASServerComponent(aasContextConfig, aasConfig);
+		aasServer.setRegistry(registry);
+
 		aasServer.startComponent();
-		System.out.println("AAS STARTED");
-		System.out.println("START UPDATER");
-		ClassLoader loader = this.getClass().getClassLoader();
+	}
+
+	private static void configureAndStartUpdaterComponent() {
+		ClassLoader loader = TestAASUpdater.class.getClassLoader();
 		RoutesConfiguration configuration = new RoutesConfiguration();
 
-		// Extend configutation for connections
 		RoutesConfigurationFactory routesFactory = new RoutesConfigurationFactory(loader);
 		configuration.addRoutes(routesFactory.create());
 
-		// Extend configutation for Kafka Source
 		KafkaDefaultConfigurationFactory kafkaConfigFactory = new KafkaDefaultConfigurationFactory(loader);
 		configuration.addDatasources(kafkaConfigFactory.create());
 
-		// Extend configuration for AAS
 		AASProducerDefaultConfigurationFactory aasConfigFactory = new AASProducerDefaultConfigurationFactory(loader);
 		configuration.addDatasinks(aasConfigFactory.create());
 
-		// Extend configuration for Jsonata
 		JsonataDefaultConfigurationFactory jsonataConfigFactory = new JsonataDefaultConfigurationFactory(loader);
 		configuration.addTransformers(jsonataConfigFactory.create());
 
 		updater = new DataBridgeComponent(configuration);
 		updater.startComponent();
-		System.out.println("UPDATER STARTED");
-		publishNewDatapoint();
-		Thread.sleep(5000);
-		checkIfPropertyIsUpdated();
-		updater.stopComponent();
-		aasServer.stopComponent();
 	}
 
-	private void checkIfPropertyIsUpdated() throws InterruptedException {
-		ConnectedAssetAdministrationShellManager manager = new ConnectedAssetAdministrationShellManager(registry);
-		ConnectedAssetAdministrationShell aas = manager.retrieveAAS(deviceAAS);
-		ISubmodel sm = aas.getSubmodels().get("ConnectedSubmodel");
-		ISubmodelElement updatedProp = sm.getSubmodelElement("ConnectedPropertyA");
-		Object propValue = updatedProp.getValue();
-		System.out.println("UpdatedPROP" + propValue);
-		assertEquals("336.36", propValue);
+	private void checkIfPropertyIsUpdated(String expectedPropertyValue, String propertyIdShort) throws InterruptedException {
+		ConnectedAssetAdministrationShell aas = getAAS(deviceAASId);
 
+		ISubmodelElement updatedProp = getSubmodelElement(aas, "ConnectedSubmodel", propertyIdShort);
+
+		Object actualPropertyValue = updatedProp.getValue();
+
+		assertEquals(expectedPropertyValue, actualPropertyValue);
 	}
 
-	private void publishNewDatapoint() throws MqttException, MqttSecurityException, MqttPersistenceException {
+	private void publishNewDatapoint(String topic)
+			throws MqttException, MqttSecurityException, MqttPersistenceException, InterruptedException {
 		String json = "{\"Account\":{\"Account Name\":\"Firefly\",\"Order\":[{\"OrderID\":\"order103\",\"Product\":[{\"Product Name\":\"Bowler Hat\",\"ProductID\":858383,\"SKU\":\"0406654608\",\"Description\":{\"Colour\":\"Purple\",\"Width\":300,\"Height\":200,\"Depth\":210,\"Weight\":0.75},\"Price\":34.45,\"Quantity\":2},{\"Product Name\":\"Trilby hat\",\"ProductID\":858236,\"SKU\":\"0406634348\",\"Description\":{\"Colour\":\"Orange\",\"Width\":300,\"Height\":200,\"Depth\":210,\"Weight\":0.6},\"Price\":21.67,\"Quantity\":1}]},{\"OrderID\":\"order104\",\"Product\":[{\"Product Name\":\"Bowler Hat\",\"ProductID\":858383,\"SKU\":\"040657863\",\"Description\":{\"Colour\":\"Purple\",\"Width\":300,\"Height\":200,\"Depth\":210,\"Weight\":0.75},\"Price\":34.45,\"Quantity\":4},{\"ProductID\":345664,\"SKU\":\"0406654603\",\"Product Name\":\"Cloak\",\"Description\":{\"Colour\":\"Black\",\"Width\":30,\"Height\":20,\"Depth\":210,\"Weight\":2},\"Price\":107.99,\"Quantity\":1}]}]}}";
 
 		String bootstrapServer = "127.0.0.1:9092";
 
-		// create producer properties
-		Properties properties = new Properties();
-		properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
-		properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-		properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+		Properties properties = createProducerProperties(bootstrapServer);
 
-		// create the producer
 		KafkaProducer<String, String> producer = new KafkaProducer<String, String>(properties);
 
-		// create a producer record
-		ProducerRecord<String, String> producerRecord = new ProducerRecord<String, String>("first-topic", json);
+		ProducerRecord<String, String> producerRecord = new ProducerRecord<String, String>(topic, json);
 
-		// send data
 		producer.send(producerRecord);
 		producer.flush();
 		producer.close();
 	}
+
+	private Properties createProducerProperties(String bootstrapServer) {
+		Properties properties = new Properties();
+		properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+		properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+		properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+		
+		return properties;
+	}
+
+	private static void configureAndStartKafkaServer() throws Exception {
+		startZookeeper();
+
+		startKafkaServer();
+	}
+
+	private static void startKafkaServer() throws IOException {
+		KafkaConfig kafkaConfig = new KafkaConfig(loadKafkaConfigProperties());
+		
+		kafkaTmpLogsDirPath = kafkaConfig.getString("log.dirs");
+		
+		createKafkaLogDirectoryIfNotExists(Paths.get(kafkaTmpLogsDirPath));
+
+		Option<String> threadNamePrefix = Option.apply("kafka-server");
+
+		kafkaServer = new KafkaServer(kafkaConfig, Time.SYSTEM, threadNamePrefix, true);
+		kafkaServer.startup();
+		
+		logger.info("Kafka server started");
+	}
+
+	private static void startZookeeper() throws Exception {
+		zookeeper = new TestingServer(2181, true);
+
+		logger.info("Zookeeper server started: " + zookeeper.getConnectString());
+	}
+
+	private static void createKafkaLogDirectoryIfNotExists(Path kafkaTempDirPath) throws IOException {		
+		if (!Files.exists(kafkaTempDirPath))
+			Files.createDirectory(kafkaTempDirPath);
+	}
+
+	private static Properties loadKafkaConfigProperties() {
+		Properties props = new Properties();
+		try (FileInputStream configFile = new FileInputStream("src/test/resources/kafkaconfig.properties")) {
+			props.load(configFile);
+			return props;
+		} catch (IOException e) {
+			e.printStackTrace();
+			throw new RuntimeException("Unable to load kafka config from properties file");
+		}
+	}
+
+	private ISubmodelElement getSubmodelElement(ConnectedAssetAdministrationShell aas, String submodelId,
+			String submodelElementId) {
+		ISubmodel sm = aas.getSubmodels().get(submodelId);
+		ISubmodelElement updatedProp = sm.getSubmodelElement(submodelElementId);
+
+		return updatedProp;
+	}
+
+	private ConnectedAssetAdministrationShell getAAS(IIdentifier identifier) {
+		ConnectedAssetAdministrationShellManager manager = new ConnectedAssetAdministrationShellManager(registry);
+		ConnectedAssetAdministrationShell aas = manager.retrieveAAS(identifier);
+		return aas;
+	}
+
+	private static void clearLogs() throws IOException {
+		Path tempLogDirPath = Paths.get(kafkaTmpLogsDirPath);
+		
+		if (Files.exists(tempLogDirPath))
+			FileUtils.deleteDirectory(new File(kafkaTmpLogsDirPath));
+	}
+
 }

--- a/databridge.examples/databridge.examples.kafka-jsonata-aas/src/test/java/org/eclipse/digitaltwin/basyx/databridge/examples/kafkajsonataaas/test/TestAASUpdater.java
+++ b/databridge.examples/databridge.examples.kafka-jsonata-aas/src/test/java/org/eclipse/digitaltwin/basyx/databridge/examples/kafkajsonataaas/test/TestAASUpdater.java
@@ -137,10 +137,8 @@ public class TestAASUpdater {
 		ConnectedAssetAdministrationShell aas = getAAS(deviceAASId);
 
 		ISubmodelElement updatedProp = getSubmodelElement(aas, "ConnectedSubmodel", propertyIdShort);
-
-		Object actualPropertyValue = updatedProp.getValue();
 		
-		return actualPropertyValue;
+		return updatedProp.getValue();
 	}
 
 	private static void configureAndStartAasServer() {
@@ -245,15 +243,14 @@ public class TestAASUpdater {
 	private ISubmodelElement getSubmodelElement(ConnectedAssetAdministrationShell aas, String submodelId,
 			String submodelElementId) {
 		ISubmodel sm = aas.getSubmodels().get(submodelId);
-		ISubmodelElement updatedProp = sm.getSubmodelElement(submodelElementId);
 
-		return updatedProp;
+		return sm.getSubmodelElement(submodelElementId);
 	}
 
 	private ConnectedAssetAdministrationShell getAAS(IIdentifier identifier) {
 		ConnectedAssetAdministrationShellManager manager = new ConnectedAssetAdministrationShellManager(registry);
-		ConnectedAssetAdministrationShell aas = manager.retrieveAAS(identifier);
-		return aas;
+
+		return manager.retrieveAAS(identifier);
 	}
 
 	private static void clearLogs() throws IOException {

--- a/databridge.examples/databridge.examples.kafka-jsonata-aas/src/test/resources/kafkaconfig.properties
+++ b/databridge.examples/databridge.examples.kafka-jsonata-aas/src/test/resources/kafkaconfig.properties
@@ -1,0 +1,6 @@
+zookeeper.connect = 127.0.0.1:2181
+port = 9092
+broker.id = 0
+log.dirs = templogs/
+offsets.topic.replication.factor = 1
+advertised.host.name = 127.0.0.1

--- a/databridge.examples/databridge.examples.plc4x-jsonata-aas/src/main/resources/plc4xconsumer.json
+++ b/databridge.examples/databridge.examples.plc4x-jsonata-aas/src/main/resources/plc4xconsumer.json
@@ -2,7 +2,7 @@
 	{
 		"uniqueId": "property1",
 		"serverUrl": "localhost",
-		"serverPort": 50201,
+		"serverPort": 8095,
 		"driver": "modbus-tcp",
 		"servicePath": "",
 		"options": "",

--- a/databridge.examples/databridge.examples.plc4x-jsonata-aas/src/test/java/org/eclipse/digitaltwin/basyx/databridge/examples/plc4xjsonataaas/test/TestAASUpdater.java
+++ b/databridge.examples/databridge.examples.plc4x-jsonata-aas/src/test/java/org/eclipse/digitaltwin/basyx/databridge/examples/plc4xjsonataaas/test/TestAASUpdater.java
@@ -66,7 +66,7 @@ import net.wimpi.modbus.procimg.SimpleRegister;
 public class TestAASUpdater {
 	
 	private static final String HOST = "127.0.0.1";
-	private static final int PORT = 50201;
+	private static final int PORT = 8095;
 	private static final int THREAD_POOL_SIZE = 3;	
 	
 	private static AASServerComponent aasServer;

--- a/databridge.examples/kafka-multiple-zookeeper-multiple-server/docker-compose.yaml
+++ b/databridge.examples/kafka-multiple-zookeeper-multiple-server/docker-compose.yaml
@@ -1,99 +1,92 @@
-version: '2.1'
+version: '3.8'
 
 services:
-  zoo1:
-    image: zookeeper:3.4.9
-    hostname: zoo1
+  zookeeper1:
+    container_name: test-zookeeper1
+    hostname: zookeeper1
+    image: confluentinc/cp-zookeeper:7.4.0
     ports:
       - "2181:2181"
     environment:
-      ZOO_MY_ID: 1
-      ZOO_PORT: 2181
-      ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
-    volumes:
-      - ./zk-multiple-kafka-multiple/zoo1/data:/data
-      - ./zk-multiple-kafka-multiple/zoo1/datalog:/datalog
-
-  zoo2:
-    image: zookeeper:3.4.9
-    hostname: zoo2
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+  
+  zookeeper2:
+    container_name: test-zookeeper2
+    hostname: zookeeper2
+    image: confluentinc/cp-zookeeper:7.4.0
     ports:
       - "2182:2182"
     environment:
-      ZOO_MY_ID: 2
-      ZOO_PORT: 2182
-      ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
-    volumes:
-      - ./zk-multiple-kafka-multiple/zoo2/data:/data
-      - ./zk-multiple-kafka-multiple/zoo2/datalog:/datalog
-
-  zoo3:
-    image: zookeeper:3.4.9
-    hostname: zoo3
+      ZOOKEEPER_CLIENT_PORT: 2182
+      ZOOKEEPER_TICK_TIME: 2000
+  
+  zookeeper3:
+    container_name: test-zookeeper3
+    hostname: zookeeper3
+    image: confluentinc/cp-zookeeper:7.4.0
     ports:
       - "2183:2183"
     environment:
-      ZOO_MY_ID: 3
-      ZOO_PORT: 2183
-      ZOO_SERVERS: server.1=zoo1:2888:3888 server.2=zoo2:2888:3888 server.3=zoo3:2888:3888
-    volumes:
-      - ./zk-multiple-kafka-multiple/zoo3/data:/data
-      - ./zk-multiple-kafka-multiple/zoo3/datalog:/datalog
-
-
+      ZOOKEEPER_CLIENT_PORT: 2183
+      ZOOKEEPER_TICK_TIME: 2000
+      
   kafka1:
-    image: confluentinc/cp-kafka:5.5.1
+    container_name: test-kafka1
     hostname: kafka1
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper1
+      - zookeeper2
+      - zookeeper3
     ports:
+      - "29092:29092"
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka1:19092,LISTENER_DOCKER_EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
-      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
       KAFKA_BROKER_ID: 1
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
-    volumes:
-      - ./zk-multiple-kafka-multiple/kafka1/data:/var/lib/kafka/data
-    depends_on:
-      - zoo1
-      - zoo2
-      - zoo3
-
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper1:2181,zookeeper2:2182,zookeeper3:2183
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
+  
   kafka2:
-    image: confluentinc/cp-kafka:5.5.1
+    container_name: test-kafka2
     hostname: kafka2
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper1
+      - zookeeper2
+      - zookeeper3
     ports:
+      - "29093:29093"
       - "9093:9093"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka2:19093,LISTENER_DOCKER_EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9093
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
-      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
       KAFKA_BROKER_ID: 2
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
-    volumes:
-      - ./zk-multiple-kafka-multiple/kafka2/data:/var/lib/kafka/data
-    depends_on:
-      - zoo1
-      - zoo2
-      - zoo3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper1:2181,zookeeper2:2182,zookeeper3:2183
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29093,PLAINTEXT_HOST://localhost:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
 
   kafka3:
-    image: confluentinc/cp-kafka:5.5.1
+    container_name: test-kafka3
     hostname: kafka3
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper1
+      - zookeeper2
+      - zookeeper3
     ports:
+      - "29094:29094"
       - "9094:9094"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka3:19094,LISTENER_DOCKER_EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
-      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181,zoo2:2182,zoo3:2183"
       KAFKA_BROKER_ID: 3
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
-    volumes:
-      - ./zk-multiple-kafka-multiple/kafka3/data:/var/lib/kafka/data
-    depends_on:
-      - zoo1
-      - zoo2
-      - zoo3
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper1:2181,zookeeper2:2182,zookeeper3:2183
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:29094,PLAINTEXT_HOST://localhost:9094
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'

--- a/databridge.examples/kafka-multiple-zookeeper-single-server/docker-compose.yaml
+++ b/databridge.examples/kafka-multiple-zookeeper-single-server/docker-compose.yaml
@@ -1,67 +1,66 @@
-version: '2.1'
+version: '3.8'
 
 services:
-  zoo1:
-    image: zookeeper:3.4.9
-    hostname: zoo1
+  zookeeper:
+    container_name: test-zookeeper
+    hostname: zookeeper
+    image: confluentinc/cp-zookeeper:7.4.0
     ports:
       - "2181:2181"
     environment:
-      ZOO_MY_ID: 1
-      ZOO_PORT: 2181
-      ZOO_SERVERS: server.1=zoo1:2888:3888
-    volumes:
-      - ./zk-single-kafka-multiple/zoo1/data:/data
-      - ./zk-single-kafka-multiple/zoo1/datalog:/datalog
-
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      
   kafka1:
-    image: confluentinc/cp-kafka:5.5.1
+    container_name: test-kafka1
     hostname: kafka1
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper
     ports:
+      - "29092:29092"
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka1:19092,LISTENER_DOCKER_EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
-      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
       KAFKA_BROKER_ID: 1
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
-    volumes:
-      - ./zk-single-kafka-multiple/kafka1/data:/var/lib/kafka/data
-    depends_on:
-      - zoo1
-
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
+  
   kafka2:
-    image: confluentinc/cp-kafka:5.5.1
+    container_name: test-kafka2
     hostname: kafka2
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper
     ports:
+      - "29093:29093"
       - "9093:9093"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka2:19093,LISTENER_DOCKER_EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9093
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
-      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
       KAFKA_BROKER_ID: 2
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
-    volumes:
-      - ./zk-single-kafka-multiple/kafka2/data:/var/lib/kafka/data
-    depends_on:
-      - zoo1
-
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka2:29093,PLAINTEXT_HOST://localhost:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
 
   kafka3:
-    image: confluentinc/cp-kafka:5.5.1
+    container_name: test-kafka3
     hostname: kafka3
+    image: confluentinc/cp-kafka:7.4.0
+    depends_on:
+      - zookeeper
     ports:
+      - "29094:29094"
       - "9094:9094"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka3:19094,LISTENER_DOCKER_EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
-      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
       KAFKA_BROKER_ID: 3
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
-    volumes:
-      - ./zk-single-kafka-multiple/kafka3/data:/var/lib/kafka/data
-    depends_on:
-      - zoo1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka3:29094,PLAINTEXT_HOST://localhost:9094
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'

--- a/databridge.examples/kafka-single-broker-server/docker-compose.yaml
+++ b/databridge.examples/kafka-single-broker-server/docker-compose.yaml
@@ -1,38 +1,30 @@
-version: '2.1'
+version: '3.8'
 
 services:
-  zoo1:
-    image: zookeeper:3.4.9
-    hostname: zoo1
+  zookeeper:
+    container_name: test-zookeeper
+    hostname: zookeeper
+    image: confluentinc/cp-zookeeper:7.4.0
     ports:
       - "2181:2181"
     environment:
-      ZOO_MY_ID: 1
-      ZOO_PORT: 2181
-      ZOO_SERVERS: server.1=zoo1:2888:3888
-    volumes:
-      - ./zk-single-kafka-single/zoo1/data:/data
-      - ./zk-single-kafka-single/zoo1/datalog:/datalog
-
-  kafka1:
-    image: confluentinc/cp-kafka:5.5.1
-    hostname: kafka1
-    ports:
-      - "9092:9092"
-      - "9999:9999"
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: LISTENER_DOCKER_INTERNAL://kafka1:19092,LISTENER_DOCKER_EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: LISTENER_DOCKER_INTERNAL:PLAINTEXT,LISTENER_DOCKER_EXTERNAL:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: LISTENER_DOCKER_INTERNAL
-      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
-      KAFKA_BROKER_ID: 1
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_JMX_PORT: 9999
-      KAFKA_JMX_HOSTNAME: ${DOCKER_HOST_IP:-127.0.0.1}
-    volumes:
-      - ./zk-single-kafka-single/kafka1/data:/var/lib/kafka/data
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      
+  kafka:
+    container_name: test-kafka
+    hostname: kafka
+    image: confluentinc/cp-kafka:7.4.0
     depends_on:
-      - zoo1
+      - zookeeper
+    ports:
+      - "29092:29092"
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'


### PR DESCRIPTION
- Addresses the issue #228 
- Updates Kafka docker compose files
- Updates Plc4x test port (fixes - sometimes bind issue in windows based systems)

The following fixes/updates have been made to address #228:
- The **seekTo** parameter value was out of date, this PR updates the correct configuration **(also suggested by user)**.
- The user observed the disconnect problem because the current example does not start the Kafka server and assumes the server is already running.
- This PR adds an embedded Kafka server (and the required Zookeeper) to the Kafka example.
- However, the [DataBridge Examples](https://github.com/eclipse-basyx/basyx-databridge/tree/main/databridge.examples) contains docker-compose files for running the required services for the Kafka example for different scenarios (in separate folders) (see kafka-multiple-zookeeper-single-server), but these have not been updated either, so this PR updates these compose files as well.
- The embedded Kafka server used in the Kafka example [TestAASUpdater](https://github.com/eclipse-basyx/basyx-databridge/tree/main/databridge.examples/databridge.examples.kafka-jsonata-aas/src/test/java/org/eclipse/digitaltwin/basyx/databridge/examples/kafkajsonataaas/test) is for the base scenario, to customise the Kafka and Zookeeper as needed you can use the docker compose files defined for different scenarios [here](https://github.com/eclipse-basyx/basyx-databridge/tree/main/databridge.examples) (see kafka-multiple-zookeeper-single-server).

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>