### PR TITLE
Adds support for multiple datasinks in one route

### DIFF
--- a/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/core/AbstractRouteCreator.java
+++ b/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/core/AbstractRouteCreator.java
@@ -53,11 +53,11 @@ public abstract class AbstractRouteCreator implements IRouteCreator {
 	public void addRouteToRouteBuilder(RouteConfiguration routeConfig) {
 		String dataSourceEndpoint = RouteCreatorHelper.getDataSourceEndpoint(routesConfiguration, routeConfig.getDatasource());
 		String[] dataSinkEndpoints = RouteCreatorHelper.getDataSinkEndpoints(routesConfiguration, routeConfig.getDatasinks());
-		String[] dataTransformerEndpoints = RouteCreatorHelper.getDataTransformerEndpoints(routesConfiguration, routeConfig.getTransformers());
+		String[][] dataTransformerEndpoints = RouteCreatorHelper.getDataTransformerEndpoints(routesConfiguration, routeConfig.getTransformers());
 		String routeId = routeConfig.getRouteId();
 
 		configureRoute(routeConfig, dataSourceEndpoint, dataSinkEndpoints, dataTransformerEndpoints, routeId);
 	}
 
-	protected abstract void configureRoute(RouteConfiguration routeConfig, String dataSourceEndpoint, String[] dataSinkEndpoints, String[] dataTransformerEndpoints, String routeId);
+	protected abstract void configureRoute(RouteConfiguration routeConfig, String dataSourceEndpoint, String[] dataSinkEndpoints, String[][] dataTransformerEndpoints, String routeId);
 }

--- a/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/core/RouteConfiguration.java
+++ b/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/core/RouteConfiguration.java
@@ -33,7 +33,7 @@ public class RouteConfiguration {
 	private String trigger;
 	private String routeId;
 	private String datasource;
-	private List<String> transformers = new ArrayList<>();
+	private List<List<String>> transformers = new ArrayList<>();
 	private List<String> datasinks = new ArrayList<>();
 
 	private Map<String, Object> triggerData = new HashMap<>();
@@ -48,7 +48,7 @@ public class RouteConfiguration {
 	 * @param transformers
 	 * @param datasinks
 	 */
-	public RouteConfiguration(String trigger, String datasource, List<String> transformers, List<String> datasinks) {
+	public RouteConfiguration(String trigger, String datasource, List<List<String>> transformers, List<String> datasinks) {
 		this.trigger = trigger;
 		this.datasource = datasource;
 		this.transformers = transformers;
@@ -81,11 +81,11 @@ public class RouteConfiguration {
 		return trigger;
 	}
 
-	public List<String> getTransformers() {
+	public List<List<String>> getTransformers() {
 		return transformers;
 	}
 
-	public void setTransformers(List<String> transformers) {
+	public void setTransformers(List<List<String>> transformers) {
 		this.transformers = transformers;
 	}
 

--- a/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/core/RouteCreatorHelper.java
+++ b/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/core/RouteCreatorHelper.java
@@ -48,11 +48,12 @@ public class RouteCreatorHelper {
 		return endpoints.toArray(new String[0]);
 	}
 
-	public static String[] getDataTransformerEndpoints(RoutesConfiguration routesConfiguration, List<String> transformerIdList) {
-		List<String> endpoints = new ArrayList<>();
-		for (String transformerId : transformerIdList) {
-			endpoints.add(routesConfiguration.getTransformers().get(transformerId).getConnectionURI());
-		}
-		return endpoints.toArray(new String[0]);
+	public static String[][] getDataTransformerEndpoints(RoutesConfiguration routesConfiguration, List<List<String>> transformerIdLists) {
+
+		return transformerIdLists.stream()
+				.map(transformerIdList -> transformerIdList.stream()
+						.map(transformerId -> routesConfiguration.getTransformers().get(transformerId).getConnectionURI())
+						.toArray(String[]::new))
+				.toArray(String[][]::new);
 	}
 }

--- a/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/event/EventRouteConfiguration.java
+++ b/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/event/EventRouteConfiguration.java
@@ -37,7 +37,7 @@ import org.eclipse.digitaltwin.basyx.databridge.core.configuration.route.core.Ro
 public class EventRouteConfiguration extends RouteConfiguration {
 	public static final String ROUTE_TRIGGER = "event";
 
-	public EventRouteConfiguration(String datasource, List<String> transformers, List<String> datasinks) {
+	public EventRouteConfiguration(String datasource, List<List<String>> transformers, List<String> datasinks) {
 		super(ROUTE_TRIGGER, datasource, transformers, datasinks);
 	}
 

--- a/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/request/RequestRouteConfiguration.java
+++ b/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/request/RequestRouteConfiguration.java
@@ -49,7 +49,7 @@ public class RequestRouteConfiguration extends RouteConfiguration {
 	private String port;
 	private String servicePath;
 
-	public RequestRouteConfiguration(String datasource, List<String> transformers, List<String> datasinks) {
+	public RequestRouteConfiguration(String datasource, List<List<String>> transformers, List<String> datasinks) {
 		super(ROUTE_TRIGGER, datasource, transformers, datasinks);
 	}
 

--- a/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/timer/TimerRouteConfiguration.java
+++ b/databridge.core/src/main/java/org/eclipse/digitaltwin/basyx/databridge/core/configuration/route/timer/TimerRouteConfiguration.java
@@ -40,7 +40,7 @@ public class TimerRouteConfiguration extends RouteConfiguration {
 
 	private String timerName;
 
-	public TimerRouteConfiguration(String datasource, List<String> transformers, List<String> datasinks) {
+	public TimerRouteConfiguration(String datasource, List<List<String>> transformers, List<String> datasinks) {
 		super(ROUTE_TRIGGER, datasource, transformers, datasinks);
 	}
 

--- a/databridge.examples/databridge.examples.aas-jsonata-http/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.aas-jsonata-http/src/main/resources/routes.json
@@ -1,7 +1,7 @@
 [
 	{
 		"datasource": "exampleAAS1",
-		"transformers": ["jsonataA"],
+		"transformers": [["jsonataA"]],
 		"datasinks":["Server1"],
 		"trigger": "timer",
 		"triggerData": {
@@ -10,7 +10,7 @@
 	},
 	{
 		"datasource": "exampleAAS2",
-		"transformers": ["jsonataB"],
+		"transformers": [["jsonataB"]],
 		"datasinks":["Server2"],
 		"trigger": "timer",
 		"triggerData": {

--- a/databridge.examples/databridge.examples.aas-jsonata-mqtt/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.aas-jsonata-mqtt/src/main/resources/routes.json
@@ -1,7 +1,7 @@
 [
 	{
 		"datasource": "exampleAAS1",
-		"transformers": ["jsonataA"],
+		"transformers": [["jsonataA"]],
 		"datasinks":["exampleMQTT1"],
 		"trigger": "timer",
 		"triggerData": {
@@ -10,7 +10,7 @@
 	},
 	{
 		"datasource": "exampleAAS2",
-		"transformers": ["jsonataA"],
+		"transformers": [["jsonataA"]],
 		"datasinks":["exampleMQTT2"],
 		"trigger": "timer",
 		"triggerData": {
@@ -19,7 +19,7 @@
 	},
 	{
 		"datasource": "exampleAAS3",
-		"transformers": ["jsonataB"],
+		"transformers": [["jsonataB"]],
 		"datasinks":["exampleMQTT3"],
 		"trigger": "timer",
 		"triggerData": {

--- a/databridge.examples/databridge.examples.activemq-jsonata-aas/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.activemq-jsonata-aas/src/main/resources/routes.json
@@ -2,13 +2,13 @@
 	{
 		"routeId": "namedRoute",
 		"datasource": "property1",
-		"transformers": ["jsonataA"],
+		"transformers": [["jsonataA"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyA"],
 		"trigger": "event"
 	},
 	{
 		"datasource": "property2",
-		"transformers": ["jsonataB"],
+		"transformers": [["jsonataB"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyB"],
 		"trigger": "event"
 	}

--- a/databridge.examples/databridge.examples.dot-aas-v3-api/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.dot-aas-v3-api/src/main/resources/routes.json
@@ -1,13 +1,13 @@
 [
 	{
 		"datasource": "mqttSource1",
-		"transformers": ["weight"],
+		"transformers": [["weight"]],
 		"datasinks": ["ConnectedTestSubmodel/DotAASV3ConformantApiProperty"],
 		"trigger": "event"
 	},
 	{
 		"datasource": "mqttSource2",
-		"transformers": ["productName"],
+		"transformers": [["productName"]],
 		"datasinks": ["ConnectedTestSubmodel/DotAASV3ConformantApiStringProperty"],
 		"trigger": "event"
 	}

--- a/databridge.examples/databridge.examples.hono-jsonata-aas/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.hono-jsonata-aas/src/main/resources/routes.json
@@ -1,7 +1,7 @@
 [
 	{
 		"datasource": "property1",
-		"transformers": ["jsonataA"],
+		"transformers": [["jsonataA"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyA"],
 		"trigger": "event"
 	}

--- a/databridge.examples/databridge.examples.httppolling-jsonata-aas/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.httppolling-jsonata-aas/src/main/resources/routes.json
@@ -1,7 +1,7 @@
 [
   {
     "datasource": "httpsource",
-    "transformers": ["jsonataA"],
+    "transformers": [["jsonataA"]],
     "datasinks": ["ConnectedSubmodel/ConnectedPropertyB"],
     "trigger": "timer",
     "triggerData" : {

--- a/databridge.examples/databridge.examples.httppolling-jsonata-delegator/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.httppolling-jsonata-delegator/src/main/resources/routes.json
@@ -1,9 +1,7 @@
 [
 	{
 		"datasource": "httpsource",
-		"transformers": [
-			"jsonataA"
-		],
+		"transformers": [["jsonataA"]],
 		"trigger": "request",
 		"triggerData": {
 			"host": "localhost",

--- a/databridge.examples/databridge.examples.httppolling-jsonata-delegator/src/test/java/org/eclipse/digitaltwin/basyx/databridge/examples/httppollingjsonatadelegator/test/TestAASUpdater.java
+++ b/databridge.examples/databridge.examples.httppolling-jsonata-delegator/src/test/java/org/eclipse/digitaltwin/basyx/databridge/examples/httppollingjsonatadelegator/test/TestAASUpdater.java
@@ -26,9 +26,11 @@ package org.eclipse.digitaltwin.basyx.databridge.examples.httppollingjsonatadele
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.io.*;
+import java.util.*;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -102,13 +104,15 @@ public class TestAASUpdater {
 		return configuration;
 	}
 	
-	private String getContentFromDelegatedEndpoint() throws IOException, ClientProtocolException {
+	private String getContentFromDelegatedEndpoint() throws IOException {
 		CloseableHttpClient client = HttpClients.createDefault();
 		HttpGet request = new HttpGet("http://localhost:8090/valueA");
 		CloseableHttpResponse resp = client.execute(request);
-		String content = new String(resp.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
+		ObjectMapper mapper = new ObjectMapper();
+		Map<String, Object> responseDataMap = mapper.readValue(resp.getEntity().getContent(), new TypeReference<Map<String, Object>>() {});
+		List<Map<String, Object>> objectsList = (List<Map<String, Object>>) responseDataMap.get("objects");
+		String content = String.valueOf(objectsList.get(0).get("value"));
 
-		client.close();
 		return content;
 	}
 	

--- a/databridge.examples/databridge.examples.kafka-jsonata-aas/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.kafka-jsonata-aas/src/main/resources/routes.json
@@ -1,13 +1,13 @@
 [
 	{
 		"datasource": "property1",
-		"transformers": ["jsonataA"],
+		"transformers": [["jsonataA"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyA"],
 		"trigger": "event"
 	},
 	{
 		"datasource": "property2",
-		"transformers": ["jsonataB"],
+		"transformers": [["jsonataB"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyB"],
 		"trigger": "event"
 	}

--- a/databridge.examples/databridge.examples.kafka-jsonatamultiple-aas/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.kafka-jsonatamultiple-aas/src/main/resources/routes.json
@@ -1,7 +1,7 @@
 [
 	{
 		"datasource": "property1",
-		"transformers": ["jsonataA", "jsonataB"],
+		"transformers": [["jsonataA", "jsonataB"], []],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyA", "ConnectedSubmodel/ConnectedPropertyB"],
 		"trigger": "event"
 	}

--- a/databridge.examples/databridge.examples.mqtt-aas_range_and_mlp/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.mqtt-aas_range_and_mlp/src/main/resources/routes.json
@@ -1,13 +1,13 @@
 [
 	{
 		"datasource": "property1",
-		"transformers": [],
+		"transformers": [[]],
 		"datasinks": ["ConnectedSubmodel/ConnectedMLP"],
 		"trigger": "event"
 	},
 	{
 		"datasource": "property2",
-		"transformers": [],
+		"transformers": [[]],
 		"datasinks": ["ConnectedSubmodel/ConnectedRange"],
 		"trigger": "event"
 	}

--- a/databridge.examples/databridge.examples.mqtt-jsonata-aas/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.mqtt-jsonata-aas/src/main/resources/routes.json
@@ -1,19 +1,19 @@
 [
 	{
 		"datasource": "property1",
-		"transformers": ["jsonataA"],
+		"transformers": [["jsonataA"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyA"],
 		"trigger": "event"
 	},
 	{
 		"datasource": "property2",
-		"transformers": ["jsonataB"],
+		"transformers": [["jsonataB"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyB"],
 		"trigger": "event"
 	},
 	{
 		"datasource": "property3",
-		"transformers": ["jsonataB"],
+		"transformers": [["jsonataB"]],
 		"datasinks": ["ConnectedTestSubmodel/ConnectedPropertyC"],
 		"trigger": "event"
 	}

--- a/databridge.examples/databridge.examples.opcua-jackson-jsonata-aas/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.opcua-jackson-jsonata-aas/src/main/resources/routes.json
@@ -1,13 +1,13 @@
 [
 	{
 		"datasource": "doublescalar",
-		"transformers": ["dataValueToJson", "jsonataExtractValue"],
+		"transformers": [["dataValueToJson", "jsonataExtractValue"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyA"],
 		"trigger": "event"
 	},
 	{
 		"datasource": "integerscalar",
-		"transformers": ["dataValueToJson", "jsonataExtractValue"],
+		"transformers": [["dataValueToJson", "jsonataExtractValue"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyB"],
 		"trigger": "event"
 	}

--- a/databridge.examples/databridge.examples.plc4x-jsonata-aas/src/main/resources/routes.json
+++ b/databridge.examples/databridge.examples.plc4x-jsonata-aas/src/main/resources/routes.json
@@ -1,7 +1,7 @@
 [
 	{
 		"datasource": "property1",
-		"transformers": ["dataValueToJson", "jsonataExtractValue"],
+		"transformers": [["dataValueToJson", "jsonataExtractValue"]],
 		"datasinks": ["ConnectedSubmodel/ConnectedPropertyA"],
 		"trigger": "event"
 	}


### PR DESCRIPTION
fixes #1 
- Makes use of multicast() from apache camel to enable multiple sinks in one route
- Enables the possibility to use a transformer on every sink in one route with the usage of multicast() and pipeline()
- Changes the syntax of the "transformers" keyword in the routes.json from a one-dimensional array to a two-dimensional array 
    -> This ensures that each sink can have its own transformer, whereby successive transformations are also possible

- an exemplary configuration of routes.json would be:
`    "datasource": "MqttConsumerAGV",`
`    "transformers": [["jsonataBatteryStatus"], ["jsonataSpeed"], ["jsonataAbsolutePosition"]],`
`    "datasinks": ["sink://tendobot/BatteryStatus",  "sink://tendobot/Speed", "sink://tendobot/AbsolutePosition"],`
`    "trigger": "event"`